### PR TITLE
Add YOLO classification utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -991,6 +991,12 @@ python scripts/convert_video_to_yolo.py --input dataset.json --output yolo_data
 python scripts/train_yolo_classification.py --data-dir yolo_data --epochs 50
 ```
 
+### Evaluate the model
+
+```bash
+python scripts/eval_yolo_classification.py --data-dir yolo_data --weights path/to/best.pt
+```
+
 
 ## 🐳 Docker
 

--- a/README.md
+++ b/README.md
@@ -973,6 +973,25 @@ print(generated_text)
 ```
 
 
+## YOLO Classification Example
+
+We provide helper scripts to convert the conversational video dataset to the
+YOLO&nbsp;11 classification format and train a classifier using the
+`ultralytics` package.
+
+### Convert the dataset
+
+```bash
+python scripts/convert_video_to_yolo.py --input dataset.json --output yolo_data
+```
+
+### Train the model
+
+```bash
+python scripts/train_yolo_classification.py --data-dir yolo_data --epochs 50
+```
+
+
 ## 🐳 Docker
 
 To simplify the deploy process, we provide docker images with pre-build environments: [qwenllm/qwenvl](https://hub.docker.com/r/qwenllm/qwenvl). You only need to install the driver and download model files to launch demos.

--- a/scripts/convert_video_to_yolo.py
+++ b/scripts/convert_video_to_yolo.py
@@ -1,0 +1,116 @@
+import os
+import json
+import random
+import argparse
+from pathlib import Path
+
+import cv2
+
+LABELS = [
+    "Pass",
+    "2-pt Shot",
+    "3-pt Shot",
+    "Free-throw",
+    "Off. Rebound",
+    "Def. Rebound",
+    "Steal",
+    "Block",
+    "Assist",
+    "Turnover",
+]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Convert video conversation dataset to YOLO classification format",
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to JSON file with video/conversation annotations",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Directory to save converted dataset",
+    )
+    parser.add_argument(
+        "--val-ratio",
+        type=float,
+        default=0.2,
+        help="Ratio of validation data split",
+    )
+    parser.add_argument(
+        "--frame-interval",
+        type=int,
+        default=5,
+        help="Interval of frames to extract from video",
+    )
+    return parser.parse_args()
+
+
+def parse_label(gpt_value: str) -> str:
+    """Parse gpt response JSON and return the label string."""
+    data = json.loads(gpt_value.strip())
+    label = data.get("label")
+    if label not in LABELS:
+        raise ValueError(f"Unknown label: {label}")
+    return label
+
+
+def extract_frames(video_path: str, out_dir: Path, interval: int):
+    """Extract frames from video and save to out_dir."""
+    cap = cv2.VideoCapture(video_path)
+    idx = 0
+    saved = 0
+    while cap.isOpened():
+        ret, frame = cap.read()
+        if not ret:
+            break
+        if idx % interval == 0:
+            img_name = f"{Path(video_path).stem}_{idx}.jpg"
+            cv2.imwrite(str(out_dir / img_name), frame)
+            saved += 1
+        idx += 1
+    cap.release()
+    return saved
+
+
+def process_split(data, split_dir: Path, interval: int):
+    for item in data:
+        video = item["video"]
+        gpt_reply = next((c["value"] for c in item["conversations"] if c["from"] == "gpt"), None)
+        if gpt_reply is None:
+            continue
+        try:
+            label = parse_label(gpt_reply)
+        except Exception as e:
+            print(f"Skip {video}: {e}")
+            continue
+        out_dir = split_dir / label
+        out_dir.mkdir(parents=True, exist_ok=True)
+        extract_frames(video, out_dir, interval)
+
+
+def main():
+    args = parse_args()
+    out_root = Path(args.output)
+    train_dir = out_root / "train"
+    val_dir = out_root / "val"
+    train_dir.mkdir(parents=True, exist_ok=True)
+    val_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(args.input, "r") as f:
+        data = json.load(f)
+
+    random.shuffle(data)
+    val_size = int(len(data) * args.val_ratio)
+    val_data = data[:val_size]
+    train_data = data[val_size:]
+
+    process_split(train_data, train_dir, args.frame_interval)
+    process_split(val_data, val_dir, args.frame_interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_yolo_classification.py
+++ b/scripts/eval_yolo_classification.py
@@ -1,0 +1,39 @@
+import argparse
+from ultralytics import YOLO
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Evaluate YOLO classification model")
+    parser.add_argument(
+        "--data-dir",
+        required=True,
+        help="Path to dataset directory in YOLO format",
+    )
+    parser.add_argument(
+        "--weights",
+        required=True,
+        help="Path to trained model weights",
+    )
+    parser.add_argument(
+        "--img-size",
+        type=int,
+        default=224,
+        help="Image size for evaluation",
+    )
+    parser.add_argument(
+        "--split",
+        default="val",
+        help="Dataset split to evaluate (val or test)",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    model = YOLO(args.weights)
+    metrics = model.val(data=args.data_dir, imgsz=args.img_size, split=args.split)
+    print(metrics)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_yolo_classification.py
+++ b/scripts/train_yolo_classification.py
@@ -1,0 +1,40 @@
+import argparse
+
+from ultralytics import YOLO
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train YOLO classification model")
+    parser.add_argument(
+        "--data-dir",
+        required=True,
+        help="Path to dataset directory in YOLO format",
+    )
+    parser.add_argument(
+        "--model",
+        default="yolov8n-cls.pt",
+        help="Initial model weights (classification)",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=50,
+        help="Number of training epochs",
+    )
+    parser.add_argument(
+        "--img-size",
+        type=int,
+        default=224,
+        help="Image size for training",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    model = YOLO(args.model)
+    model.train(data=args.data_dir, epochs=args.epochs, imgsz=args.img_size)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `convert_video_to_yolo.py` for creating a YOLO11-style dataset
- add `train_yolo_classification.py` for model training
- document YOLO classification usage

## Testing
- `python -m py_compile scripts/convert_video_to_yolo.py scripts/train_yolo_classification.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882990dbc3c8325a5b5fabe384db37f